### PR TITLE
update-to-head.sh works with openshift-knative/client

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Synchs the release-next branch to main and then triggers CI
+# Synchs the ${REPO_BRANCH} branch to main and then triggers CI
 # Usage: update-to-head.sh
 
 set -e
 REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+REPO_OWNER_NAME="openshift-knative"
+REPO_BRANCH=release-next
+REPO_BRANCH_CI="${REPO_BRANCH}-ci"
 
 # Check if there's an upstream release we need to mirror downstream
 openshift/release/mirror-upstream-branches.sh
@@ -34,9 +37,9 @@ openshift-serverless-clients.spec
 EOT
 )
 
-# Reset release-next to upstream/main.
+# Reset ${REPO_BRANCH} to upstream/main.
 git fetch upstream main
-git checkout upstream/main -B release-next
+git checkout upstream/main -B ${REPO_BRANCH}
 
 # Update openshift's main and take all needed files from there.
 git fetch openshift main
@@ -48,21 +51,22 @@ git commit -m ":open_file_folder: Update openshift specific files."
 git apply openshift/patches/*
 git commit -am ":fire: Apply carried patches."
 
-git push -f openshift release-next
+git push -f openshift ${REPO_BRANCH}
 
 # Trigger CI
-git checkout release-next -B release-next-ci
+git checkout ${REPO_BRANCH} -B ${REPO_BRANCH_CI}
+message=":robot: Triggering CI on branch '${REPO_BRANCH}' after synching to upstream/main"
 date > ci
 git add ci
-git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/main"
-git push -f openshift release-next-ci
+git commit -m "${message}"
+git push -f openshift ${REPO_BRANCH_CI}
 
 if hash hub 2>/dev/null; then
    # Test if there is already a sync PR in 
-   COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/openshift/${REPO_NAME}/pulls --flat \
-    | grep -c ":robot: Triggering CI on branch 'release-next' after synching to upstream/main") || true
+   COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/${REPO_OWNER_NAME}/${REPO_NAME}/pulls --flat \
+    | grep -c "${message}") || true
    if [ "$COUNT" = "0" ]; then
-      hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+      hub pull-request -m "${message}" -l "kind/sync-fork-to-upstream" -b ${REPO_OWNER_NAME}/${REPO_NAME}:${REPO_BRANCH} -h ${REPO_OWNER_NAME}/${REPO_NAME}:${REPO_BRANCH_CI}
    fi
 else
    echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCLI-358

These changes are required for the nightly sync job in jenkins to work on release-next branch.
Similar changes were done for Serving and Eventing. [link](https://github.com/openshift-knative/eventing/commit/51daae6ab9e06743b1ef7130253e3723851d4ffa)