### PR TITLE
SRVCLI-363 Build multiarch test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@
 
 CGO_ENABLED=0
 GOOS=linux
-TEST_IMAGES=$(shell find -L ./test/test_images ./vendor/knative.dev/serving/test/test_images/grpc-ping ./vendor/knative.dev/serving/test/test_images/multicontainer -mindepth 1 -maxdepth 2 -type f -name "*.go" -exec dirname {} \;)
+TEST_IMAGES=./test/test_images/helloworld ./vendor/knative.dev/serving/test/test_images/grpc-ping ./vendor/knative.dev/serving/test/test_images/multicontainer/servingcontainer ./vendor/knative.dev/serving/test/test_images/multicontainer/sidecarcontainer
 TEST=
-DOCKER_REPO_OVERRIDE=
+TEST_IMAGE_TAG ?= latest
 
 install: build
 	cp ./kn $(GOPATH)/bin
@@ -42,7 +42,7 @@ test-install:
 
 test-images:
 	for img in $(TEST_IMAGES); do \
-		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=latest -RBf $$img/ ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img ; \
 	done
 .PHONY: test-images
 


### PR DESCRIPTION
Simply list all the test images. The previous find command included also o./vendor/knative.dev/serving/test/test_images/grpc-ping/proto which is not correct and the image build would be redundant.

https://issues.redhat.com/browse/SRVCLI-363

This is a slightly different solution than the previous PR which was closed: https://github.com/openshift/knative-client/pull/1136

I've tested this and the multiarch images were built and pushed under quay.io/openshift-knative/client/ repo, e.g.  https://quay.io/repository/openshift-knative/client/helloworld)