### PR TITLE
[release-v1.6] Bump Quarkus platform version

### DIFF
--- a/hack/build.sh.d/kn-plugin-workflow.sh
+++ b/hack/build.sh.d/kn-plugin-workflow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly quarkus_version="2.7.6.Final-redhat-00006"
+readonly quarkus_version="2.13.5.Final-redhat-00002"
 readonly quarkus_platform_group_id="com.redhat.quarkus.platform"
 export EXTERNAL_LD_FLAGS="${EXTERNAL_LD_FLAGS:-} \
 -X github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/metadata.QuarkusVersion=${quarkus_version} \

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -31,7 +31,7 @@ readonly SERVING_BRANCH="release-next"
 readonly EVENTING_BRANCH="release-next"
 
 # The value should be updated once S-O release branch is cut
-readonly SERVERLESS_BRANCH="main"
+readonly SERVERLESS_BRANCH="release-1.27"
 
 # Determine if we're running locally or in CI.
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then


### PR DESCRIPTION
PTAL, and it will need /lgtm. Thanks!

Latest available according: https://registry.quarkus.redhat.com/client/platforms
or RH Maven GA repository.

/cc @vyasgun 