### PR TITLE
Helloworld image running with non root user

### DIFF
--- a/test/test_images/helloworld/Dockerfile
+++ b/test/test_images/helloworld/Dockerfile
@@ -21,5 +21,7 @@ RUN apk add --no-cache ca-certificates
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server
 
+USER 65532
+
 # Run the web service on container startup.
 CMD ["/server"]


### PR DESCRIPTION
Prevents error such as the following when the Pod security context has `"runAsNonRoot": true:`:
```
"container has runAsNonRoot and image will run as root (pod: \"hello-00001-deployment-65676fb5b5-29mlc_tkn-kn0(930c61ec-28cf-46b8-8dad-d6d54e896b06)\", container: user-container)"
```