### PR TITLE
fix: Check if release branch exists

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -204,11 +204,19 @@ install_knative_eventing_branch() {
 
 install_serverless_operator_branch() {
   local branch=$1
+  local repository="https://github.com/openshift-knative/serverless-operator.git"
+  git ls-remote --heads --exit-code "$repository" "$branch" >/dev/null 2>&1;
+  local repo_exists=$?
+  if [[ $repo_exists == 2 ]]; then
+    echo "Release branch doesn't exist yet, using main"
+    branch="main"
+  fi
+
   local operator_dir=/tmp/serverless-operator
   local failed=0
   header "Installing serverless operator from openshift-knative/serverless-operator branch $branch"
   rm -rf $operator_dir
-  git clone --branch $branch https://github.com/openshift-knative/serverless-operator.git $operator_dir || failed=1
+  git clone --branch $branch $repository $operator_dir || failed=1
   pushd $operator_dir
   # unset OPENSHIFT_BUILD_NAMESPACE (old CI) and OPENSHIFT_CI (new CI) as its used in serverless-operator's CI
   # environment as a switch to use CI built images, we want pre-built images of k-s-o and k-o-i

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -205,11 +205,10 @@ install_knative_eventing_branch() {
 install_serverless_operator_branch() {
   local branch=$1
   local repository="https://github.com/openshift-knative/serverless-operator.git"
-  git ls-remote --heads --exit-code "$repository" "$branch" >/dev/null 2>&1;
-  local repo_exists=$?
-  if [[ $repo_exists == 2 ]]; then
-    echo "Release branch doesn't exist yet, using main"
-    branch="main"
+  
+  if ! git ls-remote --heads --exit-code "$repository" "$branch" &>/dev/null; then
+      echo "Release branch doesn't exist yet, using main"
+      branch="main"
   fi
 
   local operator_dir=/tmp/serverless-operator


### PR DESCRIPTION
Let's add a check if release branch can be used. And set the correct values per client release branches to match S-O branches when present.

/cc @mgencur 