### PR TITLE
Only to build target platform for cross-compilation by providing goos and goarch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CGO_ENABLED=0
-GOOS=linux
+CGO_ENABLED=1
+GOOS ?=
+GOARCH ?=
 TEST_IMAGES=./test/test_images/helloworld ./vendor/knative.dev/serving/test/test_images/grpc-ping ./vendor/knative.dev/serving/test/test_images/multicontainer/servingcontainer ./vendor/knative.dev/serving/test/test_images/multicontainer/sidecarcontainer
 TEST=
 TEST_IMAGE_TAG ?= latest
@@ -27,6 +28,10 @@ install: build
 build:
 	./hack/build.sh -f
 .PHONY: build
+
+build-with-platform:
+	./hack/build.sh -p $(GOOS) $(GOARCH)
+.PHONY: build-with-platform
 
 build-cross:
 	./hack/build.sh -x

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -63,16 +63,12 @@ run() {
     exit 0
   fi
 
-# platform mode: Only to build target platform for cross-compilation and maybe run test
+# platform mode: Only to build target platform for cross-compilation
   if $(has_flag --platform -p); then
   # Extract GOOS and GOARCH from command-line arguments
     GOOS="${ARGS[1]}"
     GOARCH="${ARGS[2]}"
     go_build_with_goos_goarch "$GOOS" "$GOARCH"
-
-    if $(has_flag --test -t); then
-       go_test
-    fi
     exit 0
   fi
 
@@ -355,7 +351,7 @@ Usage: $(basename $BASH_SOURCE) [... options ...]
 with the following options:
 
 -f  --fast                    Only compile (without dep update, formatting, testing, doc gen)
--p  --platform                Specify the target platform for cross-compilation (e.g., linux-amd64, darwin-amd64)"
+-p  --platform                Specify the target platform for cross-compilation (e.g., linux amd64, darwin amd64)"
 -t  --test                    Run tests when used with --fast or --watch
 -c  --codegen                 Runs formatting, doc gen and update without compiling/testing
 -w  --watch                   Watch for source changes and recompile in fast mode
@@ -372,12 +368,13 @@ ln -s $(basedir)/hack/build.sh /usr/local/bin/kn_build.sh
 Examples:
 
 * Update deps, format, license check,
-  gen docs, compile, test: ........... build.sh
-* Compile only: ...................... build.sh --fast
-* Run only tests: .................... build.sh --test
-* Compile with tests: ................ build.sh -f -t
-* Automatic recompilation: ........... build.sh --watch
-* Build cross platform binaries: ..... build.sh --all
+  gen docs, compile, test: ........................ build.sh
+* Compile only: ................................... build.sh --fast
+* Build cross platform binaries for a platform: ... build.sh -p linux amd64
+* Run only tests: ................................. build.sh --test
+* Compile with tests: ............................. build.sh -f -t
+* Automatic recompilation: ........................ build.sh --watch
+* Build cross platform binaries: .................. build.sh --all
 EOT
 }
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -63,6 +63,19 @@ run() {
     exit 0
   fi
 
+# platform mode: Only to build target platform for cross-compilation and maybe run test
+  if $(has_flag --platform -p); then
+  # Extract GOOS and GOARCH from command-line arguments
+    GOOS="${ARGS[1]}"
+    GOARCH="${ARGS[2]}"
+    go_build_with_goos_goarch "$GOOS" "$GOARCH"
+
+    if $(has_flag --test -t); then
+       go_test
+    fi
+    exit 0
+  fi
+
   # Run only tests
   if $(has_flag --test -t); then
     go_test
@@ -130,6 +143,25 @@ go_build() {
   echo "🚧 Compile"
   # Env var exported by hack/build-flags.sh
   go build -mod=vendor -ldflags "${KN_BUILD_LD_FLAGS:-}" -o kn ./cmd/...
+
+  if $(file kn | grep -q -i "Windows"); then
+    mv kn kn.exe
+  fi
+}
+
+go_build_with_goos_goarch() {
+  GOOS="${1}"
+  GOARCH="${2}"
+  
+  if [ -z "${GOOS}" ] || [ -z "${GOARCH}" ]; then
+    echo "❌ Missing GOOS or GOARCH. Please provide both GOOS and GOARCH as arguments."
+    exit 1
+  fi
+
+  echo "🚧 Compile for GOOS=${GOOS} GOARCH=${GOARCH}"
+
+  # Env var exported by hack/build-flags.sh
+  GOOS="${GOOS}" GOARCH="${GOARCH}" go build -mod=vendor -ldflags "${KN_BUILD_LD_FLAGS:-}" -o kn ./cmd/...
 
   if $(file kn | grep -q -i "Windows"); then
     mv kn kn.exe
@@ -323,6 +355,7 @@ Usage: $(basename $BASH_SOURCE) [... options ...]
 with the following options:
 
 -f  --fast                    Only compile (without dep update, formatting, testing, doc gen)
+-p  --platform                Specify the target platform for cross-compilation (e.g., linux-amd64, darwin-amd64)"
 -t  --test                    Run tests when used with --fast or --watch
 -c  --codegen                 Runs formatting, doc gen and update without compiling/testing
 -w  --watch                   Watch for source changes and recompile in fast mode


### PR DESCRIPTION
add new **-p** or **--platform** which helps to build target platform for cross-compilation (e.g., linux-amd64, darwin-amd64)"

cc @dsimansk 