### PR TITLE
Fix missing file in sync script

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -30,7 +30,6 @@ OWNERS_ALIASES
 OWNERS
 Makefile
 package_cliartifacts.sh
-openshift-serverless-clients.spec
 EOT
 )
 


### PR DESCRIPTION
A follow-up to previous PR. There's one more reference to .spec file to clean.

/cc @Kaustubh-pande 