### PR TITLE
[release-v1.10] Fix conflicting flag w/o patching vendor

### DIFF
--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -15,6 +15,9 @@
 package main
 
 import (
+	// Hack to init conflicting `--kubeconfig` flag early
+	_ "knative.dev/pkg/test"
+
 	"errors"
 	"fmt"
 	"os"

--- a/pkg/kn/root/plugin_register.go
+++ b/pkg/kn/root/plugin_register.go
@@ -18,7 +18,7 @@ package root
 
 import (
 	// Add #plugins# import here. Don't remove this line, it triggers an automatic replacement.
-    _ "github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/plugin"
+	_ "github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/plugin"
 	_ "knative.dev/func/plugin"
 	_ "knative.dev/kn-plugin-event/pkg/plugin"
 	_ "knative.dev/kn-plugin-source-kafka/plugin"

--- a/vendor/knative.dev/pkg/environment/client_config.go
+++ b/vendor/knative.dev/pkg/environment/client_config.go
@@ -42,12 +42,8 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ServerURL, "server", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	if f := fs.Lookup("kubeconfig"); f != nil {
-		c.Kubeconfig = f.Value.String()
-	} else {
-		fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
-			"Path to a kubeconfig. Only required if out-of-cluster.")
-	}
+	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+		"Path to a kubeconfig. Only required if out-of-cluster.")
 
 	fs.IntVar(&c.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
 


### PR DESCRIPTION
There's a flag redefinition between `knative.dev/pkg` and `controller-runtime` lib used in kn-plugin-workflow. It's not happening on 1.21 because of more strict init order. It's not even a build problem, but running unit tests.

I'll fix that in `/pkg`, but for now we need a bit of hack.

First I patched the vendor source code, but it's probably safer to just force package init.

/cc @Kaustubh-pande 