### PR TITLE
Add missing `io.k8s.description` label in client artifacts

### DIFF
--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -17,4 +17,5 @@ LABEL \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 kn Client artifacts" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 kn Client artifacts" \
+      io.k8s.description="Red Hat OpenShift Serverless kn Client artifacts" \
       io.openshift.tags="kn-client-cli-artifacts"


### PR DESCRIPTION
As per title