### PR TITLE
Fix labels for cli-artifacts image to align with labels from dockerfile generator

### DIFF
--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -10,12 +10,12 @@ COPY LICENSE /licenses/
 USER 65532
 
 LABEL \
-      com.redhat.component="openshift-serverless-1-kn-cli-artifacts-rhel8-container" \
-      name="openshift-serverless-1/kn-cli-artifacts-rhel8" \
+      com.redhat.component="openshift-serverless-1-client-cli-artifacts-rhel8-container" \
+      name="openshift-serverless-1/client-cli-artifacts-rhel8" \
       version=$VERSION \
-      summary="Red Hat OpenShift Serverless 1 kn Client artifacts" \
+      summary="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
       maintainer="serverless-support@redhat.com" \
-      description="Red Hat OpenShift Serverless 1 kn Client artifacts" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn Client artifacts" \
-      io.k8s.description="Red Hat OpenShift Serverless kn Client artifacts" \
-      io.openshift.tags="kn-client-cli-artifacts"
+      description="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Cli Artifacts" \
+      io.openshift.tags="cli-artifacts"


### PR DESCRIPTION
As per title.

This should also help with the Konflux contract violation:
```
✕ [Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-client-cli-artifacts@sha256:0201243de040073a3913bb5aa6cdf5bdcbc2cf54693aee7eba091b45cc001fb3
  Reason: The "name" label should not be inherited from the parent image
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:name" to the `exclude` section of the policy configuration.
  Solution: Update the image build process to overwrite the inherited labels.
```