### PR TITLE
[release-v1.15] Update kn-plugin-event SHA to latest 1.15 version

### DIFF
--- a/openshift/ci-operator/knative-images/kn/Dockerfile
+++ b/openshift/ci-operator/knative-images/kn/Dockerfile
@@ -11,7 +11,7 @@ ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 
 ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:01e0ab5c8203ef0ca39b4e9df8fd1a8c2769ef84fce7fecefc8e8858315e71ca
-ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:1e8822f7faec7f1c346b0d530291e26941c4900426865bc56263c777687d6bc2
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:08f0b4151edd6d777e2944c6364612a5599e5a775e5150a76676a45f753c2e23
 RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/kn
 
 FROM $GO_RUNTIME


### PR DESCRIPTION
Update kn-plugin-event-sender SHA to latest: https://quay.io/repository/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-plugin-event-sender?tab=tags&tag=latest