### PR TITLE
[release-v1.18] Add dockerfile generator

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.19 as builder
 
 ARG TARGETARCH
 

--- a/openshift/ci-operator/knative-images/kn/Dockerfile
+++ b/openshift/ci-operator/knative-images/kn/Dockerfile
@@ -1,0 +1,35 @@
+# DO NOT EDIT! Generated Dockerfile for cmd/kn.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.19
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/kn
+
+FROM $GO_RUNTIME
+
+ARG VERSION=
+
+COPY --from=builder /usr/bin/main /ko-app/kn
+COPY LICENSE /licenses/
+
+USER 65532
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-kn-rhel8-container" \
+      name="openshift-serverless-1/kn-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Kn" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Kn" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Kn" \
+      io.k8s.description="Red Hat OpenShift Serverless Kn" \
+      io.openshift.tags="kn"
+
+ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,6 +1,35 @@
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for test/test_images/helloworld.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.19
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./test/test_images/helloworld
+
+FROM $GO_RUNTIME
+
+ARG VERSION=
+
+COPY --from=builder /usr/bin/main /ko-app/helloworld
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD helloworld /ko-app/helloworld
+LABEL \
+      com.redhat.component="openshift-serverless-1-test-test-images-helloworld-rhel8-container" \
+      name="openshift-serverless-1/test-test-images-helloworld-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Test Test Images Helloworld" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Test Test Images Helloworld" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Test Test Images Helloworld" \
+      io.k8s.description="Red Hat OpenShift Serverless Test Test Images Helloworld" \
+      io.openshift.tags="test-test-images-helloworld"
 
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,7 @@
+# DO NOT EDIT! Generated Dockerfile.
+
+FROM src
+
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh || true
+RUN chmod +x vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh || true

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# This script generates the productized Dockerfiles
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
+
+# --app-file-fmt is used to mimic ko build, it's assumed in --cmd flag tests
+GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
+  --root-dir "${repo_root_dir}" \
+  --generators dockerfile \
+  --excludes ".*k8s\\.io.*" \
+  --excludes ".*knative.dev/pkg/codegen.*" \
+  --excludes ".*knative.dev/hack/cmd/script.*" \
+  --app-file-fmt "/ko-app/%s"
+
+#git apply $repo_root_dir/openshift/dockerfile.patch
+FUNC_UTIL=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/kn-plugin-func-func-util:latest --override-os linux --override-arch amd64)
+EVENT_SENDER=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-136/kn-plugin-event-sender:latest --override-os linux --override-arch amd64)
+
+echo "func-util sha: ${FUNC_UTIL}"
+echo "event-sender sha: ${EVENT_SENDER}"
+
+sed -i "/RUN go build.*/ i \
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@${FUNC_UTIL}\n\
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@${EVENT_SENDER}" openshift/ci-operator/knative-images/kn/Dockerfile

--- a/openshift/images.yaml
+++ b/openshift/images.yaml
@@ -1,0 +1,2 @@
+knative.dev/client/cmd/kn: 'registry.ci.openshift.org/openshift/-kn:'
+knative.dev/client/test/test_images/helloworld: 'registry.ci.openshift.org/openshift/-test-helloworld:'


### PR DESCRIPTION
Running `make generate-release` fails, as the generate.sh file does not exist (e.g. in the current [generate-ci](https://github.com/openshift-knative/hack/actions/runs/14658039185/job/41136450034) runs).
This PR adds it. 

:exclamation: It still references the func-util and event-plugin images from the `serverless-operator-136` repo, as they don't have builds for 1.38 yet. This needs to be adjusted, as soon we have the 1.38 builds available