### PR TITLE
[release-v1.19] Add & Update Dockerfiles for 1.19

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20 as builder
 
 ARG TARGETARCH
 

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -39,7 +39,7 @@ build_root:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
 canonical_go_repository: github.com/knative/client
 images:
-- dockerfile_path: openshift/ci-operator/knative-images/client/Dockerfile
+- dockerfile_path: openshift/ci-operator/knative-images/kn/Dockerfile
   from: base
   inputs:
     bin:
@@ -47,7 +47,7 @@ images:
       - destination_dir: .
         source_path: /go/bin/kn
   to: knative-client
-- dockerfile_path: openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+- dockerfile_path: openshift/ci-operator/knative-images/cli-artifact/Dockerfile
   inputs:
     bin:
       paths:

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -1,0 +1,27 @@
+# This is not generated Dockerfile, yet!
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+ARG CLI_ARTIFACTS=registry.redhat.io/openshift-serverless-1/kn-cli-artifacts-rhel8:1.16
+
+FROM $CLI_ARTIFACTS as builder
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+RUN mkdir -p /usr/share/kn
+
+COPY --from=builder /usr/share/kn /usr/share/kn
+COPY LICENSE /licenses/
+
+USER 65532
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-cli-artifacts-rhel8-container" \
+      name="openshift-serverless-1/client-cli-artifacts-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Cli Artifacts" \
+      io.openshift.tags="cli-artifacts"

--- a/openshift/ci-operator/knative-images/kn/Dockerfile
+++ b/openshift/ci-operator/knative-images/kn/Dockerfile
@@ -1,0 +1,38 @@
+# DO NOT EDIT! Generated Dockerfile for cmd/kn.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=''
+
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@sha256:0ae40d26e834e208d0909b90fb3a37c3feb38a299034b5086f1bec69d6719eb2
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@sha256:58e3ccea5c558575fe4adc6f5f6d570ebec0934de1ba1110bc32fe76fb379c7e
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/kn
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+COPY --from=builder /usr/bin/main /ko-app/kn
+COPY LICENSE /licenses/
+
+USER 65532
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-kn-rhel8-container" \
+      name="openshift-serverless-1/client-kn-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Kn" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Kn" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Kn" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Kn" \
+      io.openshift.tags="kn"
+
+ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,6 +1,36 @@
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/grpc-ping.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=''
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main knative.dev/serving/test/test_images/grpc-ping
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+COPY --from=builder /usr/bin/main /ko-app/grpc-ping
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD grpc-ping /ko-app/grpc-ping
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-grpc-ping-rhel8-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-grpc-ping-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-grpc-ping"
 
 ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,6 +1,37 @@
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for test/test_images/helloworld.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=''
+
+RUN GOWORK=off go mod vendor
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./test/test_images/helloworld
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+COPY --from=builder /usr/bin/main /ko-app/helloworld
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD helloworld /ko-app/helloworld
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-test-test-images-helloworld-rhel8-container" \
+      name="openshift-serverless-1/client-test-test-images-helloworld-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Test Test Images Helloworld" \
+      io.openshift.tags="test-test-images-helloworld"
 
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -1,6 +1,36 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/multicontainer/servingcontainer.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=''
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main knative.dev/serving/test/test_images/multicontainer/servingcontainer
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+COPY --from=builder /usr/bin/main /ko-app/servingcontainer
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD servingcontainer /ko-app/servingcontainer
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer-rhel8-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer"
+
 ENTRYPOINT ["/ko-app/servingcontainer"]

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -1,6 +1,36 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/multicontainer/sidecarcontainer.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=''
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main knative.dev/serving/test/test_images/multicontainer/sidecarcontainer
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.19
+
+COPY --from=builder /usr/bin/main /ko-app/sidecarcontainer
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD sidecarcontainer /ko-app/sidecarcontainer
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer-rhel8-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer"
+
 ENTRYPOINT ["/ko-app/sidecarcontainer"]

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,7 @@
+# DO NOT EDIT! Generated Dockerfile.
+
+FROM src
+
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh || true
+RUN chmod +x vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh || true

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# This script generates the productized Dockerfiles
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
+
+# --app-file-fmt is used to mimic ko build, it's assumed in --cmd flag tests
+GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
+  --root-dir "${repo_root_dir}" \
+  --generators dockerfile \
+  --excludes ".*k8s\\.io.*" \
+  --excludes ".*knative.dev/pkg/codegen.*" \
+  --excludes ".*knative.dev/hack/cmd/script.*" \
+  --app-file-fmt "/ko-app/%s"
+
+#git apply $repo_root_dir/openshift/dockerfile.patch
+FUNC_UTIL=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/kn-plugin-func-func-util:latest --override-os linux --override-arch amd64)
+EVENT_SENDER=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/kn-plugin-event-sender:latest --override-os linux --override-arch amd64)
+
+echo "func-util sha: ${FUNC_UTIL}"
+echo "event-sender sha: ${EVENT_SENDER}"
+
+sed -i "/RUN go build.*/ i \
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel8@${FUNC_UTIL}\n\
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel8@${EVENT_SENDER}" openshift/ci-operator/knative-images/kn/Dockerfile

--- a/openshift/images.yaml
+++ b/openshift/images.yaml
@@ -1,0 +1,2 @@
+knative.dev/client/cmd/kn: 'registry.ci.openshift.org/openshift/-kn:'
+knative.dev/client/test/test_images/helloworld: 'registry.ci.openshift.org/openshift/-test-helloworld:'


### PR DESCRIPTION
In hacks generate-ci, I saw the client runs for 1.19 failing due to
```
--- Cleaning up generated code
make[1]: *** [Makefile:76: generate-release] Error 1
make[1]: Leaving directory '/home/runner/work/hack/hack/src/github.com/openshift-knative/hack/openshift-knative/eventing'
2025/08/01 07:01:43 Failed to generate Konflux configurations: %w eg.Wait(): failed to Generate dockerfiles with "make generate-release" for "openshift-knative/client" [release-v1.19]: [openshift-knative/client] failed to run make [generate-release]: exit status 2 - 
exit status 1
make: *** [Makefile:9: generate-ci-no-clean] Error 1
```
So saw, that it's missing the dockerfiles too.
Copied everything from 1.18 branch and adjusted the version for 1.19