### PR TITLE
[release-v1.21] Add & Update Dockerfiles for 1.21

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,17 +1,17 @@
 # DO NOT EDIT! Generated Dockerfile.
 
-FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
+FROM registry.ci.openshift.org/ocp/4.20:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20 as builder
 
 ARG TARGETARCH
 
-COPY --from=tools /usr/share/openshift/linux_$TARGETARCH/oc.rhel8 /usr/bin/oc
+COPY --from=tools /usr/share/openshift/linux_$TARGETARCH/oc.rhel9 /usr/bin/oc
 
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
-RUN yum install -y httpd-tools
+RUN dnf install -y httpd-tools
 
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 ./get-helm-3

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -30,7 +30,7 @@ base_images:
   base:
     name: ubi-minimal
     namespace: ocp
-    tag: "8"
+    tag: "9"
 binary_build_commands: |
   TAG=${tag} make install
   TAG=${tag} make build-cross

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -1,0 +1,64 @@
+# Not generated yet!
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+# ---------- BUILD STAGE ----------
+FROM $GO_BUILDER AS builder
+WORKDIR /workspace
+# Allow copying from higher directory when context is limited
+COPY . .
+ENV TAG="v1.21.0"
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel9@sha256:7213f40b00c34011a2abfe834d52902305f86d8c76be0143d8d9ac9ba1300c59
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel9@sha256:51844c9f14680b29b072e2b26bba0f5cc2fb9206adc207a2e1d3e5330d512f6d
+# Build binaries
+# RUN make build-cross-package
+RUN ./hack/build.sh -p linux amd64
+RUN ./hack/build.sh -p linux ppc64le
+RUN ./hack/build.sh -p linux s390x
+RUN ./hack/build.sh -p linux arm64
+RUN ./hack/build.sh -p darwin amd64
+RUN ./hack/build.sh -p darwin arm64
+RUN ./hack/build.sh -p windows amd64
+
+RUN chmod +x kn-linux-amd64 kn-linux-ppc64le kn-linux-s390x kn-windows-amd64.exe kn-darwin-amd64 kn-linux-arm64 kn-darwin-arm64
+
+## ---------- PACKAGING STAGE ----------
+RUN dnf install -y tar zip
+
+RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn-linux-amd64 LICENSE \
+  && tar --transform='flags=r;s|kn-linux-ppc64le|kn|' -zcf kn-linux-ppc64le.tar.gz kn-linux-ppc64le LICENSE \
+  && tar --transform='flags=r;s|kn-linux-s390x|kn|' -zcf kn-linux-s390x.tar.gz kn-linux-s390x LICENSE \
+  && tar --transform='flags=r;s|kn-darwin-amd64|kn|' -zcf kn-macos-amd64.tar.gz kn-darwin-amd64 LICENSE \
+  && tar --transform='flags=r;s|kn-linux-arm64|kn|' -zcf kn-linux-arm64.tar.gz kn-linux-arm64 LICENSE \
+  && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE
+
+RUN mkdir "windows" && mv kn-windows-amd64.exe ./windows/kn.exe && cp LICENSE ./windows/ && zip --quiet --junk-path - windows/* > kn-windows-amd64.zip
+
+# ---------- FINAL RUNTIME IMAGE ----------
+FROM $GO_RUNTIME
+RUN  mkdir -p /usr/share/kn/{linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,macos_amd64,macos_arm64,windows}
+
+COPY --from=builder /workspace/kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/
+COPY --from=builder /workspace/kn-linux-ppc64le.tar.gz /usr/share/kn/linux_ppc64le/
+COPY --from=builder /workspace/kn-linux-s390x.tar.gz /usr/share/kn/linux_s390x/
+COPY --from=builder /workspace/kn-macos-amd64.tar.gz /usr/share/kn/macos_amd64/
+COPY --from=builder /workspace/kn-windows-amd64.zip  /usr/share/kn/windows/
+COPY --from=builder /workspace/kn-linux-arm64.tar.gz /usr/share/kn/linux_arm64/
+COPY --from=builder /workspace/kn-macos-arm64.tar.gz /usr/share/kn/macos_arm64/
+COPY --from=builder /workspace/LICENSE /licenses/
+
+USER 65532
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-cli-artifacts-rhel9-container" \
+      name="openshift-serverless-1/kn-client-cli-artifacts-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Cli Artifacts" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Cli Artifacts" \
+      io.openshift.tags="cli-artifacts" \
+      release=$VERSION \
+      vendor="Red Hat, Inc." \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -61,4 +61,4 @@ LABEL \
       io.openshift.tags="cli-artifacts" \
       release=$VERSION \
       vendor="Red Hat, Inc." \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"

--- a/openshift/ci-operator/knative-images/kn/Dockerfile
+++ b/openshift/ci-operator/knative-images/kn/Dockerfile
@@ -1,0 +1,40 @@
+# DO NOT EDIT! Generated Dockerfile for cmd/kn.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel9@sha256:7213f40b00c34011a2abfe834d52902305f86d8c76be0143d8d9ac9ba1300c59
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel9@sha256:51844c9f14680b29b072e2b26bba0f5cc2fb9206adc207a2e1d3e5330d512f6d
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/kn
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.21
+
+COPY --from=builder /usr/bin/main /ko-app/kn
+COPY LICENSE /licenses/
+
+USER 65532
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-kn-client-kn-rhel9-container" \
+      name="openshift-serverless-1/kn-client-kn-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Kn" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Kn" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Kn" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Kn" \
+      io.openshift.tags="kn" \
+      vendor="Red Hat, Inc." \
+      release=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+
+ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/ci-operator/knative-images/kn/Dockerfile
+++ b/openshift/ci-operator/knative-images/kn/Dockerfile
@@ -35,6 +35,6 @@ LABEL \
       io.openshift.tags="kn" \
       vendor="Red Hat, Inc." \
       release=$VERSION \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"
 
 ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -33,6 +33,6 @@ LABEL \
       io.openshift.tags="vendor-knative.dev-serving-test-test-images-grpc-ping" \
       vendor="Red Hat, Inc." \
       release=$VERSION \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"
 
 ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,6 +1,38 @@
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/grpc-ping.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./vendor/knative.dev/serving/test/test_images/grpc-ping
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.21
+
+COPY --from=builder /usr/bin/main /ko-app/grpc-ping
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD grpc-ping /ko-app/grpc-ping
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-grpc-ping-rhel9-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-grpc-ping-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Grpc Ping" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-grpc-ping" \
+      vendor="Red Hat, Inc." \
+      release=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
 
 ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -33,6 +33,6 @@ LABEL \
       io.openshift.tags="test-test-images-helloworld" \
       vendor="Red Hat, Inc." \
       release=$VERSION \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"
 
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,6 +1,38 @@
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for test/test_images/helloworld.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./test/test_images/helloworld
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.21
+
+COPY --from=builder /usr/bin/main /ko-app/helloworld
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD helloworld /ko-app/helloworld
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-test-test-images-helloworld-rhel9-container" \
+      name="openshift-serverless-1/client-test-test-images-helloworld-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Test Test Images Helloworld" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Test Test Images Helloworld" \
+      io.openshift.tags="test-test-images-helloworld" \
+      vendor="Red Hat, Inc." \
+      release=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
 
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -33,6 +33,6 @@ LABEL \
       io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer" \
       vendor="Red Hat, Inc." \
       release=$VERSION \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"
 
 ENTRYPOINT ["/ko-app/servingcontainer"]

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -1,6 +1,38 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/multicontainer/servingcontainer.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./vendor/knative.dev/serving/test/test_images/multicontainer/servingcontainer
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.21
+
+COPY --from=builder /usr/bin/main /ko-app/servingcontainer
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD servingcontainer /ko-app/servingcontainer
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer-rhel9-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Multicontainer Servingcontainer" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-servingcontainer" \
+      vendor="Red Hat, Inc." \
+      release=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+
 ENTRYPOINT ["/ko-app/servingcontainer"]

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -1,6 +1,38 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
+# DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/serving/test/test_images/multicontainer/sidecarcontainer.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20
+ARG GO_RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal
+
+FROM $GO_BUILDER as builder
+
+WORKDIR /workspace
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./vendor/knative.dev/serving/test/test_images/multicontainer/sidecarcontainer
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.21
+
+COPY --from=builder /usr/bin/main /ko-app/sidecarcontainer
+COPY LICENSE /licenses/
+
 USER 65532
 
-ADD sidecarcontainer /ko-app/sidecarcontainer
+LABEL \
+      com.redhat.component="openshift-serverless-1-client-vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer-rhel9-container" \
+      name="openshift-serverless-1/client-vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer-rhel9" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.k8s.description="Red Hat OpenShift Serverless Client Vendor Knative.Dev Serving Test Test Images Multicontainer Sidecarcontainer" \
+      io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer" \
+      vendor="Red Hat, Inc." \
+      release=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+
 ENTRYPOINT ["/ko-app/sidecarcontainer"]

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -33,6 +33,6 @@ LABEL \
       io.openshift.tags="vendor-knative.dev-serving-test-test-images-multicontainer-sidecarcontainer" \
       vendor="Red Hat, Inc." \
       release=$VERSION \
-      cpe="cpe:/a:redhat:openshift_serverless:1.37::el9"
+      cpe="cpe:/a:redhat:openshift_serverless:1.38::el9"
 
 ENTRYPOINT ["/ko-app/sidecarcontainer"]

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,7 @@
+# DO NOT EDIT! Generated Dockerfile.
+
+FROM src
+
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh || true
+RUN chmod +x vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh || true

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -11,20 +11,11 @@ failed=0
 (( !failed )) && build_knative_client || failed=1
 (( !failed )) && run_unit_tests || failed=1
 
-if [[ "${PULL_BASE_REF:-}" == "release-next" ]]; then
-  # Midstream based setup to run on nightly versions of Serving & Eventing
-  # Serving setup & tests
-  (( !failed )) && install_serverless_operator_release_next || failed=1
-  (( !failed )) && run_client_e2e_tests serving || failed=1
-  # Eventing setup & tests
-  # (( !failed )) && install_knative_eventing_branch "${EVENTING_BRANCH}" || failed=1
-  (( !failed )) && run_client_e2e_tests eventing || failed=1
-else
-  # Serverless operator based setup for release branches
-  (( !failed )) && install_serverless_operator_branch "${SERVERLESS_BRANCH}" || failed=1
-  (( !failed )) && run_client_e2e_tests serving || failed=1
-  (( !failed )) && run_client_e2e_tests eventing || failed=1
-fi
+# Serverless operator based setup for release branches
+(( !failed )) && install_serverless_operator || failed=1
+(( !failed )) && run_client_e2e_tests serving || failed=1
+(( !failed )) && run_client_e2e_tests eventing || failed=1
+
 
 (( failed )) && exit 1
 

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This script generates the productized Dockerfiles
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function install_generate_hack_tool() {
+  go install github.com/openshift-knative/hack/cmd/generate@latest
+  return $?
+}
+
+repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
+
+install_generate_hack_tool || exit 1
+
+# --app-file-fmt is used to mimic ko build, it's assumed in --cmd flag tests
+"$(go env GOPATH)"/bin/generate \
+  --root-dir "${repo_root_dir}" \
+  --generators dockerfile \
+  --excludes ".*k8s\\.io.*" \
+  --excludes ".*knative.dev/pkg/codegen.*" \
+  --excludes ".*knative.dev/hack/cmd/script.*" \
+  --app-file-fmt "/ko-app/%s" \
+  --generate-rpms-lock-file \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.20"
+
+
+#git apply $repo_root_dir/openshift/dockerfile.patch
+FUNC_UTIL=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/kn-plugin-func-func-util:1.37.1 --override-os linux --override-arch amd64)
+EVENT_SENDER=$(skopeo inspect -n --format '{{.Digest}}' docker://quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-137/kn-plugin-event-sender:1.37.1 --override-os linux --override-arch amd64)
+
+echo "func-util sha: ${FUNC_UTIL}"
+echo "event-sender sha: ${EVENT_SENDER}"
+
+echo "Update kn image refs"
+sed -i "/RUN go build.*/ i \
+ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel9@${FUNC_UTIL}\n\
+ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel9@${EVENT_SENDER}" openshift/ci-operator/knative-images/kn/Dockerfile
+
+echo "Update cli-artifacts image refs"
+sed -i "s|ENV KN_PLUGIN_FUNC_UTIL_IMAGE.*|ENV KN_PLUGIN_FUNC_UTIL_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-func-func-util-rhel9@${FUNC_UTIL}|g" openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+sed -i "s|ENV KN_PLUGIN_EVENT_SENDER_IMAGE.*|ENV KN_PLUGIN_EVENT_SENDER_IMAGE=registry.redhat.io/openshift-serverless-1/kn-plugin-event-sender-rhel9@${EVENT_SENDER}|g" openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+

--- a/openshift/images.yaml
+++ b/openshift/images.yaml
@@ -1,0 +1,5 @@
+knative.dev/client/cmd/kn: registry.ci.openshift.org/openshift/knative-client-kn:knative-v1.21
+knative.dev/client/test/test_images/helloworld: registry.ci.openshift.org/openshift/knative-client-test-helloworld:knative-v1.21
+knative.dev/serving/test/test_images/grpc-ping: registry.ci.openshift.org/openshift/knative-client-test-grpc-ping:knative-v1.21
+knative.dev/serving/test/test_images/multicontainer/servingcontainer: registry.ci.openshift.org/openshift/knative-client-test-servingcontainer:knative-v1.21
+knative.dev/serving/test/test_images/multicontainer/sidecarcontainer: registry.ci.openshift.org/openshift/knative-client-test-sidecarcontainer:knative-v1.21

--- a/openshift/project.yaml
+++ b/openshift/project.yaml
@@ -1,0 +1,3 @@
+project:
+  tag: knative-v1.21
+  imagePrefix: knative-client

--- a/openshift/release/kn.yaml
+++ b/openshift/release/kn.yaml
@@ -1,0 +1,21 @@
+plugins:
+  - name: kn-plugin-source-kafka
+    module: knative.dev/kn-plugin-source-kafka
+    pluginImportPath: knative.dev/kn-plugin-source-kafka/plugin
+    version: knative-v1.21.0
+  - name: kn-plugin-event
+    module: knative.dev/kn-plugin-event
+    pluginImportPath: knative.dev/kn-plugin-event/pkg/plugin
+    version: v1.21.0
+    replace:
+      - module: knative.dev/kn-plugin-event
+        moduleSource: github.com/openshift-knative/kn-plugin-event
+        version: release-1.21
+  - name: kn-plugin-func
+    module: knative.dev/func
+    pluginImportPath: knative.dev/func/plugin
+    version: v1.21.0
+    replace:
+      - module: knative.dev/func
+        moduleSource: github.com/openshift-knative/kn-plugin-func
+        version: release-v1.21


### PR DESCRIPTION
In hack repos generate-ci, we see currently the following error

```
2026/02/10 14:17:02 Failed to generate Konflux configurations: %w eg.Wait(): failed to Generate dockerfiles with "make generate-release" for "openshift-knative/client" [release-v1.21]: [openshift-knative/client] failed to run make [generate-release]: exit status 2 - 
exit status 1
```
This is because we're missing the generate scripts in this branch (not automated yet :upside_down_face: )

I copied the openshift/ folder from release-v1.17 branch and adjusted the references to 1.21.