### PR TITLE
SRVCOM-4808: Prepare Serverless client binary artifacts for Konflux signing pipeline

### DIFF
--- a/artifact_manifest.json
+++ b/artifact_manifest.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "1.0",
+  "description": "OpenShift Serverless Client CLI artifacts for Konflux signing workflow",
+  "artifacts": [
+    {
+      "variant": "detached-signing",
+      "platform": "windows/amd64",
+      "description": "Windows CLI binary needing Authenticode signing",
+      "config": {
+        "output_filename": "kn-windows-amd64.zip",
+        "signing": {
+          "files": [
+            "kn.exe"
+          ]
+        }
+      },
+      "layers": [
+        {
+          "name": "windows-binary",
+          "description": "Windows CLI tarball source",
+          "files": [
+            "releases/kn/windows/kn-windows-amd64.tar.gz"
+          ]
+        }
+      ]
+    },
+    {
+      "variant": "detached-signing",
+      "platform": "darwin/amd64",
+      "description": "macOS Intel binary needing Apple signing/notarization",
+      "config": {
+        "output_filename": "kn-macos-amd64.tar.gz",
+        "signing": {
+          "files": [
+            "kn"
+          ]
+        }
+      },
+      "layers": [
+        {
+          "name": "macos-intel-binary",
+          "description": "macOS Intel tarball source",
+          "files": [
+            "releases/kn/macos_amd64/kn-macos-amd64.tar.gz"
+          ]
+        }
+      ]
+    },
+    {
+      "variant": "detached-signing",
+      "platform": "darwin/arm64",
+      "description": "macOS Apple Silicon binary needing Apple signing/notarization",
+      "config": {
+        "output_filename": "kn-macos-arm64.tar.gz",
+        "signing": {
+          "files": [
+            "kn"
+          ]
+        }
+      },
+      "layers": [
+        {
+          "name": "macos-arm-binary",
+          "description": "macOS ARM tarball source",
+          "files": [
+            "releases/kn/macos_arm64/kn-macos-arm64.tar.gz"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -23,7 +23,7 @@ RUN ./hack/build.sh -p windows amd64
 RUN chmod +x kn-linux-amd64 kn-linux-ppc64le kn-linux-s390x kn-windows-amd64.exe kn-darwin-amd64 kn-linux-arm64 kn-darwin-arm64
 
 ## ---------- PACKAGING STAGE ----------
-RUN dnf install -y tar
+RUN dnf install -y tar zip
 
 RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn-linux-amd64 LICENSE \
   && tar --transform='flags=r;s|kn-linux-ppc64le|kn|' -zcf kn-linux-ppc64le.tar.gz kn-linux-ppc64le LICENSE \
@@ -33,6 +33,7 @@ RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn
   && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE \
   && tar --transform='flags=r;s|kn-windows-amd64.exe|kn.exe|' -zcf kn-windows-amd64.tar.gz kn-windows-amd64.exe LICENSE
 
+RUN mkdir "windows" && cp kn-windows-amd64.exe ./windows/kn.exe && cp LICENSE ./windows/ && zip --quiet --junk-path - windows/* > kn-windows-amd64.zip
 # ---------- FINAL RUNTIME IMAGE ----------
 FROM $GO_RUNTIME
 
@@ -48,6 +49,7 @@ COPY --from=builder /workspace/kn-windows-amd64.tar.gz  /releases/kn/windows/
 COPY --from=builder /workspace/kn-linux-arm64.tar.gz /releases/kn/linux_arm64/
 COPY --from=builder /workspace/kn-macos-arm64.tar.gz /releases/kn/macos_arm64/
 COPY --from=builder /workspace/LICENSE /releases/kn/LICENSE
+COPY --from=builder /workspace/kn-windows-amd64.zip  /usr/share/kn/windows/
 
 # Backward compatibility for existing workflow that expect /usr/share/kn.
 RUN ln -s /releases/kn/linux_amd64/kn-linux-amd64.tar.gz     /usr/share/kn/linux_amd64/kn-linux-amd64.tar.gz && \

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -32,20 +32,24 @@ RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn
   && tar --transform='flags=r;s|kn-linux-arm64|kn|' -zcf kn-linux-arm64.tar.gz kn-linux-arm64 LICENSE \
   && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE
 
-RUN mkdir "windows" && mv kn-windows-amd64.exe ./windows/kn.exe && cp LICENSE ./windows/ && zip --quiet --junk-path - windows/* > kn-windows-amd64.zip
+RUN mkdir "windows" && mv kn-windows-amd64.exe ./windows/kn.exe && cp LICENSE ./windows/ && tar -zcf kn-windows-amd64.tar.gz -C windows kn.exe LICENSE
 
 # ---------- FINAL RUNTIME IMAGE ----------
 FROM $GO_RUNTIME
 RUN  mkdir -p /usr/share/kn/{linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,macos_amd64,macos_arm64,windows}
+# Create the /releases directory required by the extraction pipeline [3, 4]
+RUN mkdir -p /releases
 
-COPY --from=builder /workspace/kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/
-COPY --from=builder /workspace/kn-linux-ppc64le.tar.gz /usr/share/kn/linux_ppc64le/
-COPY --from=builder /workspace/kn-linux-s390x.tar.gz /usr/share/kn/linux_s390x/
-COPY --from=builder /workspace/kn-macos-amd64.tar.gz /usr/share/kn/macos_amd64/
-COPY --from=builder /workspace/kn-windows-amd64.zip  /usr/share/kn/windows/
-COPY --from=builder /workspace/kn-linux-arm64.tar.gz /usr/share/kn/linux_arm64/
-COPY --from=builder /workspace/kn-macos-arm64.tar.gz /usr/share/kn/macos_arm64/
-COPY --from=builder /workspace/LICENSE /licenses/
+COPY --from=builder /workspace/kn-linux-amd64.tar.gz /releases/kn/linux_amd64/
+COPY --from=builder /workspace/kn-linux-ppc64le.tar.gz /releases/kn/linux_ppc64le/
+COPY --from=builder /workspace/kn-linux-s390x.tar.gz /releases/kn/linux_s390x/
+COPY --from=builder /workspace/kn-macos-amd64.tar.gz /releases/kn/macos_amd64/
+COPY --from=builder /workspace/kn-windows-amd64.tar.gz  /releases/kn/windows/
+COPY --from=builder /workspace/kn-linux-arm64.tar.gz /releases/kn/linux_arm64/
+COPY --from=builder /workspace/kn-macos-arm64.tar.gz /releases/kn/macos_arm64/
+COPY --from=builder /workspace/LICENSE /releases/kn/LICENSE
+# Set appropriate permissions
+RUN chmod +x /releases/*
 
 USER 65532
 

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -31,7 +31,7 @@ RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn
   && tar --transform='flags=r;s|kn-darwin-amd64|kn|' -zcf kn-macos-amd64.tar.gz kn-darwin-amd64 LICENSE \
   && tar --transform='flags=r;s|kn-linux-arm64|kn|' -zcf kn-linux-arm64.tar.gz kn-linux-arm64 LICENSE \
   && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE \
-  && tar --transform='flags=r;s|kn-windows-amd64\.exe|kn.exe|' -zcf kn-windows-amd64.tar.gz kn-windows-amd64.exe LICENSE
+  && tar --transform='flags=r;s|kn-windows-amd64.exe|kn.exe|' -zcf kn-windows-amd64.tar.gz kn-windows-amd64.exe LICENSE
 
 # ---------- FINAL RUNTIME IMAGE ----------
 FROM $GO_RUNTIME

--- a/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
+++ b/openshift/ci-operator/knative-images/cli-artifacts/Dockerfile
@@ -23,22 +23,22 @@ RUN ./hack/build.sh -p windows amd64
 RUN chmod +x kn-linux-amd64 kn-linux-ppc64le kn-linux-s390x kn-windows-amd64.exe kn-darwin-amd64 kn-linux-arm64 kn-darwin-arm64
 
 ## ---------- PACKAGING STAGE ----------
-RUN dnf install -y tar zip
+RUN dnf install -y tar
 
 RUN tar --transform='flags=r;s|kn-linux-amd64|kn|' -zcf kn-linux-amd64.tar.gz kn-linux-amd64 LICENSE \
   && tar --transform='flags=r;s|kn-linux-ppc64le|kn|' -zcf kn-linux-ppc64le.tar.gz kn-linux-ppc64le LICENSE \
   && tar --transform='flags=r;s|kn-linux-s390x|kn|' -zcf kn-linux-s390x.tar.gz kn-linux-s390x LICENSE \
   && tar --transform='flags=r;s|kn-darwin-amd64|kn|' -zcf kn-macos-amd64.tar.gz kn-darwin-amd64 LICENSE \
   && tar --transform='flags=r;s|kn-linux-arm64|kn|' -zcf kn-linux-arm64.tar.gz kn-linux-arm64 LICENSE \
-  && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE
-
-RUN mkdir "windows" && mv kn-windows-amd64.exe ./windows/kn.exe && cp LICENSE ./windows/ && tar -zcf kn-windows-amd64.tar.gz -C windows kn.exe LICENSE
+  && tar --transform='flags=r;s|kn-darwin-arm64|kn|' -zcf kn-macos-arm64.tar.gz kn-darwin-arm64 LICENSE \
+  && tar --transform='flags=r;s|kn-windows-amd64\.exe|kn.exe|' -zcf kn-windows-amd64.tar.gz kn-windows-amd64.exe LICENSE
 
 # ---------- FINAL RUNTIME IMAGE ----------
 FROM $GO_RUNTIME
-RUN  mkdir -p /usr/share/kn/{linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,macos_amd64,macos_arm64,windows}
-# Create the /releases directory required by the extraction pipeline [3, 4]
-RUN mkdir -p /releases
+
+RUN mkdir -p \
+    /releases/kn/{linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,macos_amd64,macos_arm64,windows} \
+    /usr/share/kn/{linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,macos_amd64,macos_arm64,windows}
 
 COPY --from=builder /workspace/kn-linux-amd64.tar.gz /releases/kn/linux_amd64/
 COPY --from=builder /workspace/kn-linux-ppc64le.tar.gz /releases/kn/linux_ppc64le/
@@ -48,8 +48,16 @@ COPY --from=builder /workspace/kn-windows-amd64.tar.gz  /releases/kn/windows/
 COPY --from=builder /workspace/kn-linux-arm64.tar.gz /releases/kn/linux_arm64/
 COPY --from=builder /workspace/kn-macos-arm64.tar.gz /releases/kn/macos_arm64/
 COPY --from=builder /workspace/LICENSE /releases/kn/LICENSE
-# Set appropriate permissions
-RUN chmod +x /releases/*
+
+# Backward compatibility for existing workflow that expect /usr/share/kn.
+RUN ln -s /releases/kn/linux_amd64/kn-linux-amd64.tar.gz     /usr/share/kn/linux_amd64/kn-linux-amd64.tar.gz && \
+    ln -s /releases/kn/linux_arm64/kn-linux-arm64.tar.gz     /usr/share/kn/linux_arm64/kn-linux-arm64.tar.gz && \
+    ln -s /releases/kn/linux_ppc64le/kn-linux-ppc64le.tar.gz /usr/share/kn/linux_ppc64le/kn-linux-ppc64le.tar.gz && \
+    ln -s /releases/kn/linux_s390x/kn-linux-s390x.tar.gz     /usr/share/kn/linux_s390x/kn-linux-s390x.tar.gz && \
+    ln -s /releases/kn/macos_amd64/kn-macos-amd64.tar.gz     /usr/share/kn/macos_amd64/kn-macos-amd64.tar.gz && \
+    ln -s /releases/kn/macos_arm64/kn-macos-arm64.tar.gz     /usr/share/kn/macos_arm64/kn-macos-arm64.tar.gz && \
+    ln -s /releases/kn/windows/kn-windows-amd64.tar.gz       /usr/share/kn/windows/kn-windows-amd64.tar.gz && \
+    ln -s /releases/kn/LICENSE                               /usr/share/kn/LICENSE
 
 USER 65532
 


### PR DESCRIPTION
This PR prepares the OpenShift Serverless Client binary release for the Konflux signing and CDN publishing pipeline.
## Changes

- Update the Dockerfile to package all release artifacts as .tar.gz archives, including the Windows binary, to meet the requirements of the Konflux push-artifacts-to-cdn pipeline.

- Modify the Windows packaging flow to archive kn.exe and LICENSE as kn-windows-amd64.tar.gz. The release pipeline will automatically extract, Authenticode-sign, and repackage the binary into the final .zip artifact for Content Gateway distribution.

- Add artifact_manifest.json at the repository root to describe the artifacts that require detached signing.

- Configure signing metadata for:
  - Windows (windows/amd64) using Authenticode signing.
  - macOS Intel (darwin/amd64) using Apple signing/notarization.
  - macOS Apple Silicon (darwin/arm64) using Apple signing/notarization.

fix for https://redhat.atlassian.net/browse/SRVCOM-4808
cc @dsimansk 